### PR TITLE
fix (IOSFirmwareInstaller.swift): we no longer set the state to idle if its not one of the well known cases

### DIFF
--- a/Laerdal.McuMgr.Bindings.Android/mcumgr-laerdal-wrapper/src/main/java/no/laerdal/mcumgr_laerdal_wrapper/AndroidFirmwareInstaller.java
+++ b/Laerdal.McuMgr.Bindings.Android/mcumgr-laerdal-wrapper/src/main/java/no/laerdal/mcumgr_laerdal_wrapper/AndroidFirmwareInstaller.java
@@ -328,6 +328,9 @@ public class AndroidFirmwareInstaller
                     _handler.removeCallbacks(_graphUpdater);
                     setState(EAndroidFirmwareInstallationState.CONFIRMING);
                     break;
+
+                default:
+                    break; // setState(.idle);  //dont
             }
         }
 

--- a/Laerdal.McuMgr.Bindings.iOS/McuMgrBindingsiOS/McuMgrBindingsiOS/IOSFirmwareInstaller.swift
+++ b/Laerdal.McuMgr.Bindings.iOS/McuMgrBindingsiOS/McuMgrBindingsiOS/IOSFirmwareInstaller.swift
@@ -269,8 +269,9 @@ extension IOSFirmwareInstaller: FirmwareUpgradeDelegate { //todo   calculate thr
             setState(.confirming);
         case .success:
             setState(.complete);
+
         default:
-            setState(.idle);
+            break // setState(.idle);  //dont
         }
     }
 


### PR DESCRIPTION
   this addresses a subtle harmless bug which was causing the retry counter to be
   incremented in the UI side because the UI would think that the underlying
   mechanism initiated a retry while in fact it didnt