### PR TITLE
clean (AndroidFileDownloader.java): remove non-applicable parameters windowCapacity and memoryAlignment considering that they're not currently supported for file-downloading operations

### DIFF
--- a/Laerdal.McuMgr.Bindings.Android.Native/mcumgr-laerdal-wrapper/src/main/java/no/laerdal/mcumgr_laerdal_wrapper/AndroidFileDownloader.java
+++ b/Laerdal.McuMgr.Bindings.Android.Native/mcumgr-laerdal-wrapper/src/main/java/no/laerdal/mcumgr_laerdal_wrapper/AndroidFileDownloader.java
@@ -37,16 +37,14 @@ public class AndroidFileDownloader
      * @param remoteFilePath the remote-file-path to the file on the remote device that you wish to download
      * @param initialMtuSize sets the initial MTU for the connection that the McuMgr BLE-transport sets up for the firmware installation that will follow.
      *                       Note that if less than 0 it gets ignored and if it doesn't fall within the range [23, 517] it will cause a hard error.
-     * @param windowCapacity specifies the windows-capacity for the data transfers of the BLE connection - if zero or negative the value provided gets ignored and will be set to 1 by default
-     * @param memoryAlignment specifies the memory-alignment to use for the data transfers of the BLE connection - if zero or negative the value provided gets ignored and will be set to 1 by default
      *
      * @return a verdict indicating whether the file uploading was started successfully or not
      */
     public EAndroidFileDownloaderVerdict beginDownload(
             final String remoteFilePath,
-            final int initialMtuSize,
-            final int windowCapacity, //todo   should we keep this or remove it?  it doesnt seem to be applicable to the file-downloader
-            final int memoryAlignment //todo   should we keep this or remove it?  it doesnt seem to be applicable to the file-downloader
+            final int initialMtuSize
+            // final int windowCapacity, //theoretically nordic firmwares at some point will support this for downloads   but as of Q3 2024 there is no support for this
+            // final int memoryAlignment //this doesnt make sense for downloading   it only makes sense in uploading scenarios    https://github.com/NordicSemiconductor/Android-nRF-Connect-Device-Manager/issues/188#issuecomment-2391146897
     )
     {
         if (_currentState != EAndroidFileDownloaderState.NONE  //if the download is already in progress we bail out

--- a/Laerdal.McuMgr.Bindings.Android/Laerdal.McuMgr.Bindings.Android.csproj
+++ b/Laerdal.McuMgr.Bindings.Android/Laerdal.McuMgr.Bindings.Android.csproj
@@ -62,10 +62,10 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 
         <!-- these versions are getting replaced by the build script in one swift pass -->
-        <Version>1.0.1167.0</Version>
-        <FileVersion>1.0.1167.0</FileVersion>
-        <PackageVersion>1.0.1167.0</PackageVersion>
-        <AssemblyVersion>1.0.1167.0</AssemblyVersion>
+        <Version>1.0.1168.0</Version>
+        <FileVersion>1.0.1168.0</FileVersion>
+        <PackageVersion>1.0.1168.0</PackageVersion>
+        <AssemblyVersion>1.0.1168.0</AssemblyVersion>
 
         <Title>$(PackageId)</Title>
         <Owners>$(Authors)</Owners>

--- a/Laerdal.McuMgr.Bindings.MacCatalyst/Laerdal.McuMgr.Bindings.MacCatalyst.csproj
+++ b/Laerdal.McuMgr.Bindings.MacCatalyst/Laerdal.McuMgr.Bindings.MacCatalyst.csproj
@@ -73,10 +73,10 @@
         <AllowedReferenceRelatedFileExtensions>$(AllowedReferenceRelatedFileExtensions);.pdb</AllowedReferenceRelatedFileExtensions>
 
         <!-- these versions are getting replaced by the build script in one swift pass -->
-        <Version>1.0.1167.0</Version>
-        <FileVersion>1.0.1167.0</FileVersion>
-        <PackageVersion>1.0.1167.0</PackageVersion>
-        <AssemblyVersion>1.0.1167.0</AssemblyVersion>
+        <Version>1.0.1168.0</Version>
+        <FileVersion>1.0.1168.0</FileVersion>
+        <PackageVersion>1.0.1168.0</PackageVersion>
+        <AssemblyVersion>1.0.1168.0</AssemblyVersion>
 
         <Title>$(PackageId)</Title>
         <Summary>McuMgr Bindings for MacCatalyst - MAUI ready</Summary>

--- a/Laerdal.McuMgr.Bindings.NetStandard/Laerdal.McuMgr.Bindings.NetStandard.csproj
+++ b/Laerdal.McuMgr.Bindings.NetStandard/Laerdal.McuMgr.Bindings.NetStandard.csproj
@@ -37,10 +37,10 @@
         <AllowedReferenceRelatedFileExtensions>$(AllowedReferenceRelatedFileExtensions);.pdb</AllowedReferenceRelatedFileExtensions>
 
         <!-- these versions are getting replaced by the build script in one swift pass --> 
-        <Version>1.0.1167.0</Version>
-        <FileVersion>1.0.1167.0</FileVersion>
-        <PackageVersion>1.0.1167.0</PackageVersion>
-        <AssemblyVersion>1.0.1167.0</AssemblyVersion>
+        <Version>1.0.1168.0</Version>
+        <FileVersion>1.0.1168.0</FileVersion>
+        <PackageVersion>1.0.1168.0</PackageVersion>
+        <AssemblyVersion>1.0.1168.0</AssemblyVersion>
 
         <Title>$(PackageId)</Title>
         <Summary>McuMgr C# Implementation (WIP)</Summary>

--- a/Laerdal.McuMgr.Bindings.iOS/Laerdal.McuMgr.Bindings.iOS.csproj
+++ b/Laerdal.McuMgr.Bindings.iOS/Laerdal.McuMgr.Bindings.iOS.csproj
@@ -73,10 +73,10 @@
         <AllowedReferenceRelatedFileExtensions>$(AllowedReferenceRelatedFileExtensions);.pdb</AllowedReferenceRelatedFileExtensions>
 
         <!-- these versions are getting replaced by the build script in one swift pass -->
-        <Version>1.0.1167.0</Version>
-        <FileVersion>1.0.1167.0</FileVersion>
-        <PackageVersion>1.0.1167.0</PackageVersion>
-        <AssemblyVersion>1.0.1167.0</AssemblyVersion>
+        <Version>1.0.1168.0</Version>
+        <FileVersion>1.0.1168.0</FileVersion>
+        <PackageVersion>1.0.1168.0</PackageVersion>
+        <AssemblyVersion>1.0.1168.0</AssemblyVersion>
 
         <Title>$(PackageId)</Title>
         <Summary>McuMgr Bindings for iOS - MAUI ready</Summary>

--- a/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.BeginDownload.ShouldThrowArgumentException_GivenInvalidRemoteFilePath.cs
+++ b/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.BeginDownload.ShouldThrowArgumentException_GivenInvalidRemoteFilePath.cs
@@ -49,13 +49,11 @@ namespace Laerdal.McuMgr.Tests.FileDownloader
                 _mockedFileData = mockedFileData;
             }
 
-            public override EFileDownloaderVerdict BeginDownload(string remoteFilePath, int? initialMtuSize = null, int? windowCapacity = null, int? memoryAlignment = null)
+            public override EFileDownloaderVerdict BeginDownload(string remoteFilePath, int? initialMtuSize = null)
             {
                 var verdict = base.BeginDownload(
                     remoteFilePath,
-                    initialMtuSize: initialMtuSize,
-                    windowCapacity: windowCapacity,
-                    memoryAlignment: memoryAlignment
+                    initialMtuSize: initialMtuSize
                 );
 
                 Task.Run(async () => //00 vital

--- a/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.MultipleFilesDownloadAsync.ShouldCompleteSuccessfully_GivenNoFilesToDownload.cs
+++ b/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.MultipleFilesDownloadAsync.ShouldCompleteSuccessfully_GivenNoFilesToDownload.cs
@@ -41,13 +41,11 @@ namespace Laerdal.McuMgr.Tests.FileDownloader
             {
             }
 
-            public override EFileDownloaderVerdict BeginDownload(string remoteFilePath, int? initialMtuSize = null, int? windowCapacity = null, int? memoryAlignment = null)
+            public override EFileDownloaderVerdict BeginDownload(string remoteFilePath, int? initialMtuSize = null)
             {
                 var verdict = base.BeginDownload(
                     remoteFilePath,
-                    initialMtuSize: initialMtuSize,
-                    windowCapacity: windowCapacity,
-                    memoryAlignment: memoryAlignment
+                    initialMtuSize: initialMtuSize
                 );
 
                 Task.Run(async () => //00 vital

--- a/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.MultipleFilesDownloadAsync.ShouldCompleteSuccessfully_GivenVariousFilesToDownload.cs
+++ b/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.MultipleFilesDownloadAsync.ShouldCompleteSuccessfully_GivenVariousFilesToDownload.cs
@@ -82,13 +82,11 @@ namespace Laerdal.McuMgr.Tests.FileDownloader
             }
 
             private int _retryCountForProblematicFile; 
-            public override EFileDownloaderVerdict BeginDownload(string remoteFilePath, int? initialMtuSize = null, int? windowCapacity = null, int? memoryAlignment = null)
+            public override EFileDownloaderVerdict BeginDownload(string remoteFilePath, int? initialMtuSize = null)
             {
                 var verdict = base.BeginDownload(
                     remoteFilePath: remoteFilePath,
-                    initialMtuSize: initialMtuSize,
-                    windowCapacity: windowCapacity,
-                    memoryAlignment: memoryAlignment
+                    initialMtuSize: initialMtuSize
                 );
 
                 Task.Run(async () => //00 vital

--- a/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.MultipleFilesDownloadAsync.ShouldThrowArgumentException_GivenPathCollectionWithErroneousFilesToDownload.cs
+++ b/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.MultipleFilesDownloadAsync.ShouldThrowArgumentException_GivenPathCollectionWithErroneousFilesToDownload.cs
@@ -49,13 +49,11 @@ namespace Laerdal.McuMgr.Tests.FileDownloader
             {
             }
 
-            public override EFileDownloaderVerdict BeginDownload(string remoteFilePath, int? initialMtuSize = null, int? windowCapacity = null, int? memoryAlignment = null)
+            public override EFileDownloaderVerdict BeginDownload(string remoteFilePath, int? initialMtuSize = null)
             {
                 var verdict = base.BeginDownload(
                     remoteFilePath: remoteFilePath,
-                    initialMtuSize: initialMtuSize,
-                    windowCapacity: windowCapacity,
-                    memoryAlignment: memoryAlignment
+                    initialMtuSize: initialMtuSize
                 );
 
                 Task.Run(async () => //00 vital

--- a/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.MultipleFilesDownloadAsync.ShouldThrowNullArgumentException_GivenNullForFilesToDownload.cs
+++ b/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.MultipleFilesDownloadAsync.ShouldThrowNullArgumentException_GivenNullForFilesToDownload.cs
@@ -40,13 +40,11 @@ namespace Laerdal.McuMgr.Tests.FileDownloader
             {
             }
 
-            public override EFileDownloaderVerdict BeginDownload(string remoteFilePath, int? initialMtuSize = null, int? windowCapacity = null, int? memoryAlignment = null)
+            public override EFileDownloaderVerdict BeginDownload(string remoteFilePath, int? initialMtuSize = null)
             {
                 var verdict = base.BeginDownload(
                     remoteFilePath: remoteFilePath,
-                    initialMtuSize: initialMtuSize,
-                    windowCapacity: windowCapacity,
-                    memoryAlignment: memoryAlignment
+                    initialMtuSize: initialMtuSize
                 );
 
                 Task.Run(async () => //00 vital

--- a/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.SingleFileDownloadAsync.ShouldCompleteSuccessfullyByFallingBackToFailsafeSettings_GivenFlakyConnection.cs
+++ b/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.SingleFileDownloadAsync.ShouldCompleteSuccessfullyByFallingBackToFailsafeSettings_GivenFlakyConnection.cs
@@ -93,19 +93,14 @@ namespace Laerdal.McuMgr.Tests.FileDownloader
             private int _tryCounter;
             public override EFileDownloaderVerdict BeginDownload(
                 string remoteFilePath,
-                int? initialMtuSize = null, //  android only
-                int? windowCapacity = null, //  android only
-                int? memoryAlignment = null //  android only
+                int? initialMtuSize = null //  android only
             )
             {
                 _tryCounter++;
 
                 var verdict = base.BeginDownload(
                     remoteFilePath: remoteFilePath,
-
-                    initialMtuSize: initialMtuSize, //   android only
-                    windowCapacity: windowCapacity, //   android only
-                    memoryAlignment: memoryAlignment //  android only
+                    initialMtuSize: initialMtuSize //   android only
                 );
 
                 Task.Run(async () => //00 vital
@@ -131,22 +126,6 @@ namespace Laerdal.McuMgr.Tests.FileDownloader
                     if (_tryCounter == _maxTriesCount && initialMtuSize != AndroidTidbits.FailSafeBleConnectionSettings.InitialMtuSize)
                     {
                         BugDetected = $"[BUG DETECTED] The very last try should be with {nameof(initialMtuSize)} set to {AndroidTidbits.FailSafeBleConnectionSettings.InitialMtuSize} but it's set to {initialMtuSize?.ToString() ?? "(null)"} instead - something is wrong!";
-                        StateChangedAdvertisement(remoteFilePath, EFileDownloaderState.Downloading, EFileDownloaderState.Error); // order
-                        FatalErrorOccurredAdvertisement(remoteFilePath, BugDetected); //                                            order
-                        return;
-                    }
-
-                    if (_tryCounter == _maxTriesCount && windowCapacity != AndroidTidbits.FailSafeBleConnectionSettings.WindowCapacity)
-                    {
-                        BugDetected = $"[BUG DETECTED] The very last try should be with {nameof(windowCapacity)} set to {AndroidTidbits.FailSafeBleConnectionSettings.WindowCapacity} but it's set to {windowCapacity?.ToString() ?? "(null)"} instead - something is wrong!";
-                        StateChangedAdvertisement(remoteFilePath, EFileDownloaderState.Downloading, EFileDownloaderState.Error); // order
-                        FatalErrorOccurredAdvertisement(remoteFilePath, BugDetected); //                                            order
-                        return;
-                    }
-
-                    if (_tryCounter == _maxTriesCount && memoryAlignment != AndroidTidbits.FailSafeBleConnectionSettings.MemoryAlignment)
-                    {
-                        BugDetected = $"[BUG DETECTED] The very last try should be with {nameof(memoryAlignment)} set to {AndroidTidbits.FailSafeBleConnectionSettings.MemoryAlignment} but it's set to {memoryAlignment?.ToString() ?? "(null)"} instead - something is wrong!";
                         StateChangedAdvertisement(remoteFilePath, EFileDownloaderState.Downloading, EFileDownloaderState.Error); // order
                         FatalErrorOccurredAdvertisement(remoteFilePath, BugDetected); //                                            order
                         return;

--- a/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.SingleFileDownloadAsync.ShouldCompleteSuccessfully_GivenGreenNativeFileDownloader.cs
+++ b/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.SingleFileDownloadAsync.ShouldCompleteSuccessfully_GivenGreenNativeFileDownloader.cs
@@ -84,15 +84,13 @@ namespace Laerdal.McuMgr.Tests.FileDownloader
             }
 
             private int _tryCount;
-            public override EFileDownloaderVerdict BeginDownload(string remoteFilePath, int? initialMtuSize = null, int? windowCapacity = null, int? memoryAlignment = null)
+            public override EFileDownloaderVerdict BeginDownload(string remoteFilePath, int? initialMtuSize = null)
             {
                 _tryCount++;
 
                 var verdict = base.BeginDownload(
                     remoteFilePath: remoteFilePath,
-                    initialMtuSize: initialMtuSize,
-                    windowCapacity: windowCapacity,
-                    memoryAlignment: memoryAlignment
+                    initialMtuSize: initialMtuSize
                 );
 
                 Task.Run(async () => //00 vital

--- a/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.SingleFileDownloadAsync.ShouldThrowAllDownloadAttemptsFailedException_GivenFatalErrorMidflight.cs
+++ b/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.SingleFileDownloadAsync.ShouldThrowAllDownloadAttemptsFailedException_GivenFatalErrorMidflight.cs
@@ -71,13 +71,11 @@ namespace Laerdal.McuMgr.Tests.FileDownloader
                 _ = mockedFileData;
             }
 
-            public override EFileDownloaderVerdict BeginDownload(string remoteFilePath, int? initialMtuSize = null, int? windowCapacity = null, int? memoryAlignment = null)
+            public override EFileDownloaderVerdict BeginDownload(string remoteFilePath, int? initialMtuSize = null)
             {
                 var verdict = base.BeginDownload(
                     remoteFilePath: remoteFilePath,
-                    initialMtuSize: initialMtuSize,
-                    windowCapacity: windowCapacity,
-                    memoryAlignment: memoryAlignment
+                    initialMtuSize: initialMtuSize
                 );
 
                 Task.Run(async () => //00 vital

--- a/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.SingleFileDownloadAsync.ShouldThrowAllDownloadAttemptsFailedException_GivenRogueNativeErrorMessage.cs
+++ b/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.SingleFileDownloadAsync.ShouldThrowAllDownloadAttemptsFailedException_GivenRogueNativeErrorMessage.cs
@@ -82,13 +82,11 @@ namespace Laerdal.McuMgr.Tests.FileDownloader
                 _nativeErrorMessageForFileNotFound = nativeErrorMessageForFileNotFound;
             }
 
-            public override EFileDownloaderVerdict BeginDownload(string remoteFilePath, int? initialMtuSize = null, int? windowCapacity = null, int? memoryAlignment = null)
+            public override EFileDownloaderVerdict BeginDownload(string remoteFilePath, int? initialMtuSize = null)
             {
                 var verdict = base.BeginDownload(
                     remoteFilePath: remoteFilePath,
-                    initialMtuSize: initialMtuSize,
-                    windowCapacity: windowCapacity,
-                    memoryAlignment: memoryAlignment
+                    initialMtuSize: initialMtuSize
                 );
 
                 Task.Run(async () => //00 vital

--- a/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.SingleFileDownloadAsync.ShouldThrowArgumentException_GivenEmptyRemoteFilePath.cs
+++ b/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.SingleFileDownloadAsync.ShouldThrowArgumentException_GivenEmptyRemoteFilePath.cs
@@ -45,13 +45,11 @@ namespace Laerdal.McuMgr.Tests.FileDownloader
                 _mockedFileData = mockedFileData;
             }
 
-            public override EFileDownloaderVerdict BeginDownload(string remoteFilePath, int? initialMtuSize = null, int? windowCapacity = null, int? memoryAlignment = null)
+            public override EFileDownloaderVerdict BeginDownload(string remoteFilePath, int? initialMtuSize = null)
             {
                 var verdict = base.BeginDownload(
                     remoteFilePath: remoteFilePath,
-                    initialMtuSize: initialMtuSize,
-                    windowCapacity: windowCapacity,
-                    memoryAlignment: memoryAlignment
+                    initialMtuSize: initialMtuSize
                 );
 
                 Task.Run(async () => //00 vital

--- a/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.SingleFileDownloadAsync.ShouldThrowDownloadCancelledException_GivenCancellationRequestMidflight.cs
+++ b/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.SingleFileDownloadAsync.ShouldThrowDownloadCancelledException_GivenCancellationRequestMidflight.cs
@@ -91,7 +91,7 @@ namespace Laerdal.McuMgr.Tests.FileDownloader
                 //     a best effort basis and this is exactly what we are testing here
             }
 
-            public override EFileDownloaderVerdict BeginDownload(string remoteFilePath, int? initialMtuSize = null, int? windowCapacity = null, int? memoryAlignment = null)
+            public override EFileDownloaderVerdict BeginDownload(string remoteFilePath, int? initialMtuSize = null)
             {
                 _currentRemoteFilePath = remoteFilePath;
                 _cancellationTokenSource = new CancellationTokenSource();
@@ -103,9 +103,7 @@ namespace Laerdal.McuMgr.Tests.FileDownloader
 
                 var verdict = base.BeginDownload(
                     remoteFilePath: remoteFilePath,
-                    initialMtuSize: initialMtuSize,
-                    windowCapacity: windowCapacity,
-                    memoryAlignment: memoryAlignment
+                    initialMtuSize: initialMtuSize
                 );
 
                 Task.Run(async () => //00 vital

--- a/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.SingleFileDownloadAsync.ShouldThrowDownloadInternalErrorException_GivenErroneousNativeFileDownloader.cs
+++ b/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.SingleFileDownloadAsync.ShouldThrowDownloadInternalErrorException_GivenErroneousNativeFileDownloader.cs
@@ -34,13 +34,11 @@ namespace Laerdal.McuMgr.Tests.FileDownloader
             {
             }
 
-            public override EFileDownloaderVerdict BeginDownload(string remoteFilePath, int? initialMtuSize = null, int? windowCapacity = null, int? memoryAlignment = null)
+            public override EFileDownloaderVerdict BeginDownload(string remoteFilePath, int? initialMtuSize = null)
             {
                 base.BeginDownload(
                     remoteFilePath: remoteFilePath,
-                    initialMtuSize: initialMtuSize,
-                    windowCapacity: windowCapacity,
-                    memoryAlignment: memoryAlignment
+                    initialMtuSize: initialMtuSize
                 );
 
                 Thread.Sleep(100);

--- a/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.SingleFileDownloadAsync.ShouldThrowDownloadTimeoutException_GivenTooSmallTimeout.cs
+++ b/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.SingleFileDownloadAsync.ShouldThrowDownloadTimeoutException_GivenTooSmallTimeout.cs
@@ -51,13 +51,11 @@ namespace Laerdal.McuMgr.Tests.FileDownloader
             {
             }
 
-            public override EFileDownloaderVerdict BeginDownload(string remoteFilePath, int? initialMtuSize = null, int? windowCapacity = null, int? memoryAlignment = null)
+            public override EFileDownloaderVerdict BeginDownload(string remoteFilePath, int? initialMtuSize = null)
             {
                 var verdict = base.BeginDownload(
                     remoteFilePath: remoteFilePath,
-                    initialMtuSize: initialMtuSize,
-                    windowCapacity: windowCapacity,
-                    memoryAlignment: memoryAlignment
+                    initialMtuSize: initialMtuSize
                 );
 
                 Task.Run(async () => //00 vital

--- a/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.SingleFileDownloadAsync.ShouldThrowRemoteFileNotFoundException_GivenNonExistentFilepath.cs
+++ b/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.SingleFileDownloadAsync.ShouldThrowRemoteFileNotFoundException_GivenNonExistentFilepath.cs
@@ -85,13 +85,11 @@ namespace Laerdal.McuMgr.Tests.FileDownloader
                 _nativeErrorMessageForFileNotFound = nativeErrorMessageForFileNotFound;
             }
 
-            public override EFileDownloaderVerdict BeginDownload(string remoteFilePath, int? initialMtuSize = null, int? windowCapacity = null, int? memoryAlignment = null)
+            public override EFileDownloaderVerdict BeginDownload(string remoteFilePath, int? initialMtuSize = null)
             {
                 var verdict = base.BeginDownload(
                     remoteFilePath: remoteFilePath,
-                    initialMtuSize: initialMtuSize,
-                    windowCapacity: windowCapacity,
-                    memoryAlignment: memoryAlignment
+                    initialMtuSize: initialMtuSize
                 );
 
                 Task.Run(async () => //00 vital

--- a/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.cs
+++ b/Laerdal.McuMgr.Tests/FileDownloader/FileDownloaderTestbed.cs
@@ -30,9 +30,7 @@ namespace Laerdal.McuMgr.Tests.FileDownloader
 
             public virtual EFileDownloaderVerdict BeginDownload(
                 string remoteFilePath,
-                int? initialMtuSize = null,
-                int? windowCapacity = null,
-                int? memoryAlignment = null
+                int? initialMtuSize = null
             )
             {
                 BeginDownloadCalled = true;

--- a/Laerdal.McuMgr/Droid/FileDownloader/FileDownloader.cs
+++ b/Laerdal.McuMgr/Droid/FileDownloader/FileDownloader.cs
@@ -94,16 +94,12 @@ namespace Laerdal.McuMgr.FileDownloader
 
             public EFileDownloaderVerdict BeginDownload(
                 string remoteFilePath,
-                int? initialMtuSize = null, //  android only
-                int? windowCapacity = null, //  android only
-                int? memoryAlignment = null //  android only
+                int? initialMtuSize = null //  android only
             )
             {
                 return TranslateFileDownloaderVerdict(base.BeginDownload(
                     remoteFilePath: remoteFilePath,
-                    initialMtuSize: initialMtuSize ?? -1,
-                    windowCapacity: windowCapacity ?? -1,  //todo  remove these if they turn out to be non-applicable to file-downloading
-                    memoryAlignment: memoryAlignment ?? -1
+                    initialMtuSize: initialMtuSize ?? -1
                 ));
             }
             

--- a/Laerdal.McuMgr/Laerdal.McuMgr.csproj
+++ b/Laerdal.McuMgr/Laerdal.McuMgr.csproj
@@ -71,10 +71,10 @@
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
         <!-- these versions are getting replaced by the build script in one swift pass -->
-        <Version>1.0.1167.0</Version>
-        <FileVersion>1.0.1167.0</FileVersion>
-        <PackageVersion>1.0.1167.0</PackageVersion>
-        <AssemblyVersion>1.0.1167.0</AssemblyVersion>
+        <Version>1.0.1168.0</Version>
+        <FileVersion>1.0.1168.0</FileVersion>
+        <PackageVersion>1.0.1168.0</PackageVersion>
+        <AssemblyVersion>1.0.1168.0</AssemblyVersion>
 
         <Title>$(PackageId)</Title>
         <Owners>$(Authors)</Owners>
@@ -168,21 +168,21 @@
     
     <!-- ANDROID -->
     <ItemGroup Condition=" '$(IsAndroid)' == 'true' ">
-        <PackageReference Include="Laerdal.McuMgr.Bindings.Android" Version="1.0.1167.0"/>
+        <PackageReference Include="Laerdal.McuMgr.Bindings.Android" Version="1.0.1168.0"/>
     </ItemGroup>
 
     <!-- IOS/MacCatalyst -->
     <ItemGroup Condition=" '$(IsIOS)' == 'true' ">
-        <PackageReference Include="Laerdal.McuMgr.Bindings.iOS" Version="1.0.1167.0"/>
+        <PackageReference Include="Laerdal.McuMgr.Bindings.iOS" Version="1.0.1168.0"/>
     </ItemGroup>
 
     <ItemGroup Condition=" '$(IsNetXMacCatalyst)' == 'true' and '$(Should_Skip_MacCatalyst)' != 'true' ">
-        <PackageReference Include="Laerdal.McuMgr.Bindings.MacCatalyst" Version="1.0.1167.0"/>
+        <PackageReference Include="Laerdal.McuMgr.Bindings.MacCatalyst" Version="1.0.1168.0"/>
     </ItemGroup>
 
     <!-- NETSTANDARD -->
     <ItemGroup Condition=" '$(IsNetStandard)' == 'true' ">
-        <PackageReference Include="Laerdal.McuMgr.Bindings.NetStandard" Version="1.0.1167.0"/>
+        <PackageReference Include="Laerdal.McuMgr.Bindings.NetStandard" Version="1.0.1168.0"/>
     </ItemGroup>
 
 </Project>

--- a/Laerdal.McuMgr/Shared/FileDownloader/Contracts/Native/INativeFileDownloaderCommandableProxy.cs
+++ b/Laerdal.McuMgr/Shared/FileDownloader/Contracts/Native/INativeFileDownloaderCommandableProxy.cs
@@ -6,6 +6,6 @@ namespace Laerdal.McuMgr.FileDownloader.Contracts.Native
     {
         void Cancel();
         void Disconnect();
-        EFileDownloaderVerdict BeginDownload(string remoteFilePath, int? initialMtuSize = null, int? windowCapacity = null, int? memoryAlignment = null);
+        EFileDownloaderVerdict BeginDownload(string remoteFilePath, int? initialMtuSize = null);
     }
 }

--- a/Laerdal.McuMgr/Shared/FileDownloader/FileDownloader.cs
+++ b/Laerdal.McuMgr/Shared/FileDownloader/FileDownloader.cs
@@ -51,9 +51,7 @@ namespace Laerdal.McuMgr.FileDownloader
 
             var verdict = _nativeFileDownloaderProxy.BeginDownload(
                 remoteFilePath: remoteFilePath,
-                initialMtuSize: initialMtuSize,
-                windowCapacity: windowCapacity,
-                memoryAlignment: memoryAlignment
+                initialMtuSize: initialMtuSize
             );
 
             return verdict;

--- a/Laerdal.McuMgr/iOS/FileDownloader/FileDownloader.cs
+++ b/Laerdal.McuMgr/iOS/FileDownloader/FileDownloader.cs
@@ -91,9 +91,7 @@ namespace Laerdal.McuMgr.FileDownloader
 
             public EFileDownloaderVerdict BeginDownload(
                 string remoteFilePath,
-                int? initialMtuSize = null, //  android only
-                int? windowCapacity = null, //  android only
-                int? memoryAlignment = null //  android only
+                int? initialMtuSize = null //  android only
             )
             {
                 return TranslateFileDownloaderVerdict(_nativeFileDownloader.BeginDownload(remoteFilePath: remoteFilePath));


### PR DESCRIPTION
Source:

https://github.com/NordicSemiconductor/Android-nRF-Connect-Device-Manager/issues/188#issuecomment-2391146897
