### PR TITLE
[MAN-528] Upgrade native ios libs to 1.9.1

### DIFF
--- a/Laerdal.McuMgr.Bindings.Android/Laerdal.McuMgr.Bindings.Android.csproj
+++ b/Laerdal.McuMgr.Bindings.Android/Laerdal.McuMgr.Bindings.Android.csproj
@@ -133,12 +133,12 @@
 
     <ItemGroup Condition=" '$(IsNetX)' == 'true' " >
         <!-- these dependencies have been field-tested and are known to work at least as far back as Android 10.0 -->
-        <PackageReference Include="Xamarin.AndroidX.Core" Version="1.15.0.1" PrivateAssets="All" />
+        <PackageReference Include="Xamarin.AndroidX.Core" Version="1.15.0.2" PrivateAssets="All" />
 
         <!-- the mcumgr-file-uploading aspect KotlinX.Coroutines jars with version 1.7+ -->
         <!-- to work as intended otherwise we get missing symbols errors in runtime     -->
-        <PackageReference Include="Xamarin.Kotlin.StdLib" Version="2.0.21.1" />
-        <PackageReference Include="Xamarin.KotlinX.Coroutines.Android" Version="1.9.0.1" />
+        <PackageReference Include="Xamarin.Kotlin.StdLib" Version="2.0.21.2" />
+        <PackageReference Include="Xamarin.KotlinX.Coroutines.Android" Version="1.9.0.2" />
     </ItemGroup>
 
 </Project>

--- a/Laerdal.McuMgr.Bindings.MacCatalystAndIos.Native/McuMgrBindingsiOS/McuMgrBindingsiOS.xcodeproj/project.pbxproj
+++ b/Laerdal.McuMgr.Bindings.MacCatalystAndIos.Native/McuMgrBindingsiOS/McuMgrBindingsiOS.xcodeproj/project.pbxproj
@@ -466,7 +466,7 @@
 			repositoryURL = "https://github.com/NordicSemiconductor/IOS-nRF-Connect-Device-Manager.git";
 			requirement = {
 				kind = exactVersion;
-				version = 1.9.0;
+				version = 1.9.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
- **feat ([ios/maccatalyst] Laerdal.McuMgr.Bindings.iOS/MacCatalyst.csproj -> project.pbxproj): upgrade IOS-nRF-Connect-Device-Manager to 1.9.1 (old was: 1.9.0)**
- **fix (Laerdal.McuMgr.Bindings.Android.csproj): upgrade Xamarin.AndroidX/Kotlin nugets to their latest contemporary versions**
