### PR TITLE
[MAN-619] File-transfer-events: include filepath of resource

### DIFF
--- a/Laerdal.McuMgr.Bindings.Android.Native/mcumgr-laerdal-wrapper/src/main/java/no/laerdal/mcumgr_laerdal_wrapper/AndroidFileDownloader.java
+++ b/Laerdal.McuMgr.Bindings.Android.Native/mcumgr-laerdal-wrapper/src/main/java/no/laerdal/mcumgr_laerdal_wrapper/AndroidFileDownloader.java
@@ -231,7 +231,7 @@ public class AndroidFileDownloader
 
         setState(EAndroidFileDownloaderState.IDLE);
         busyStateChangedAdvertisement(true);
-        fileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(0, 0, 0);
+        fileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(_remoteFilePathSanitized, 0, 0, 0);
     }
 
     private void ensureTransportIsInitializedExactlyOnce(int initialMtuSize)
@@ -333,7 +333,7 @@ public class AndroidFileDownloader
 
         if (oldState == EAndroidFileDownloaderState.DOWNLOADING && newState == EAndroidFileDownloaderState.COMPLETE) //00
         {
-            fileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(100, 0, 0);
+            fileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(_remoteFilePathSanitized, 100, 0, 0);
         }
 
         //00 trivial hotfix to deal with the fact that the filedownload progress% doesnt fill up to 100%
@@ -423,7 +423,7 @@ public class AndroidFileDownloader
     }
 
     @Contract(pure = true)
-    public void fileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(final int progressPercentage, final float currentThroughputInKbps, final float totalAverageThroughputInKbps)
+    public void fileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(final String resourceId, final int progressPercentage, final float currentThroughputInKbps, final float totalAverageThroughputInKbps)
     {
         //this method is intentionally empty   its meant to be overridden by csharp binding libraries to intercept updates
     }
@@ -458,6 +458,7 @@ public class AndroidFileDownloader
             float totalAverageThroughputInKbps = calculateTotalAverageThroughputInKbps(totalBytesSentSoFar, timestampInMs);
 
             fileDownloadProgressPercentageAndDataThroughputChangedAdvertisement( // convert to percent
+                    _remoteFilePathSanitized,
                     fileDownloadProgressPercentage,
                     currentThroughputInKbps,
                     totalAverageThroughputInKbps
@@ -505,7 +506,7 @@ public class AndroidFileDownloader
         @Override
         public void onDownloadFailed(@NonNull final McuMgrException exception)
         {
-            fileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(0, 0, 0);
+            fileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(_remoteFilePathSanitized, 0, 0, 0);
             onError(exception.getMessage(), exception);
             setLoggingEnabledOnConnection(true);
             busyStateChangedAdvertisement(false);
@@ -516,7 +517,7 @@ public class AndroidFileDownloader
         @Override
         public void onDownloadCanceled()
         {
-            fileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(0, 0, 0);
+            fileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(_remoteFilePathSanitized, 0, 0, 0);
             setState(EAndroidFileDownloaderState.CANCELLED);
             cancelledAdvertisement();
             setLoggingEnabledOnConnection(true);
@@ -528,7 +529,7 @@ public class AndroidFileDownloader
         @Override
         public void onDownloadCompleted(byte @NotNull [] data)
         {
-            //fileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(100, 0, 0); //no need this is taken care of inside setState()
+            //fileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(_remoteFilePathSanitized, 100, 0, 0); //no need this is taken care of inside setState()
 
             setState(EAndroidFileDownloaderState.COMPLETE); //                    order  vital
             downloadCompletedAdvertisement(_remoteFilePathSanitized, data); //    order  vital

--- a/Laerdal.McuMgr.Bindings.MacCatalystAndIos.Native/McuMgrBindingsiOS/McuMgrBindingsiOS/IOSListenerForFileDownloader.swift
+++ b/Laerdal.McuMgr.Bindings.MacCatalystAndIos.Native/McuMgrBindingsiOS/McuMgrBindingsiOS/IOSListenerForFileDownloader.swift
@@ -3,12 +3,12 @@ import Foundation
 @objc
 public protocol IOSListenerForFileDownloader {
     func logMessageAdvertisement(_ message: String, _ category: String, _ level: String, _ resource: String?)
-    func fatalErrorOccurredAdvertisement(_ resource: String?, _ errorMessage: String, _ globalErrorCode: Int)
+    func fatalErrorOccurredAdvertisement(_ resourceId: String?, _ errorMessage: String, _ globalErrorCode: Int)
 
     func cancelledAdvertisement()
 
-    func stateChangedAdvertisement(_ resource: String?, _ oldState: EIOSFileDownloaderState, _ newState: EIOSFileDownloaderState)
+    func stateChangedAdvertisement(_ resourceId: String?, _ oldState: EIOSFileDownloaderState, _ newState: EIOSFileDownloaderState)
     func busyStateChangedAdvertisement(_ busyNotIdle: Bool)
-    func downloadCompletedAdvertisement(_ resource: String?, _ data: [UInt8])
-    func fileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(_ progressPercentage: Int, _ averageThroughput: Float32, _ totalAverageThroughputInKbps: Float32)
+    func downloadCompletedAdvertisement(_ resourceId: String?, _ data: [UInt8])
+    func fileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(_ resourceId: String?, _ progressPercentage: Int, _ averageThroughput: Float32, _ totalAverageThroughputInKbps: Float32)
 }

--- a/Laerdal.McuMgr.Tests/FileDownloadingTestbed/SingleFileDownloadAsync_ShouldCompleteSuccessfullyByFallingBackToFailsafeSettings_GivenFlakyConnection.cs
+++ b/Laerdal.McuMgr.Tests/FileDownloadingTestbed/SingleFileDownloadAsync_ShouldCompleteSuccessfullyByFallingBackToFailsafeSettings_GivenFlakyConnection.cs
@@ -121,19 +121,19 @@ namespace Laerdal.McuMgr.Tests.FileDownloadingTestbed
                     StateChangedAdvertisement(remoteFilePath, EFileDownloaderState.Idle, EFileDownloaderState.Downloading);
 
                     await Task.Delay(5);
-                    FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(00, 00, 00);
+                    FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(remoteFilePath, 00, 00, 00);
                     await Task.Delay(5);
-                    FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(10, 10, 10);
+                    FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(remoteFilePath, 10, 10, 10);
                     await Task.Delay(5);
-                    FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(20, 10, 10);
+                    FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(remoteFilePath, 20, 10, 10);
                     await Task.Delay(5);
-                    FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(30, 10, 10);
+                    FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(remoteFilePath, 30, 10, 10);
                     await Task.Delay(5);
-                    FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(40, 10, 10);
+                    FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(remoteFilePath, 40, 10, 10);
                     await Task.Delay(5);
-                    FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(50, 10, 10);
+                    FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(remoteFilePath, 50, 10, 10);
                     await Task.Delay(5);
-                    FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(60, 10, 10);
+                    FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(remoteFilePath, 60, 10, 10);
 
                     if (_tryCounter == _maxTriesCount && initialMtuSize == null)
                     {
@@ -152,13 +152,13 @@ namespace Laerdal.McuMgr.Tests.FileDownloadingTestbed
                     }
 
                     await Task.Delay(5);
-                    FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(70, 10, 10);
+                    FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(remoteFilePath, 70, 10, 10);
                     await Task.Delay(5);
-                    FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(80, 10, 10);
+                    FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(remoteFilePath, 80, 10, 10);
                     await Task.Delay(5);
-                    FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(90, 10, 10);
+                    FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(remoteFilePath, 90, 10, 10);
                     await Task.Delay(5);
-                    FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(100, 10, 10);
+                    FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(remoteFilePath, 100, 10, 10);
                     
                     StateChangedAdvertisement(remoteFilePath, EFileDownloaderState.Downloading, EFileDownloaderState.Complete); // order
                     DownloadCompletedAdvertisement(remoteFilePath, _expectedData); //                                              order

--- a/Laerdal.McuMgr.Tests/FileDownloadingTestbed/_.cs
+++ b/Laerdal.McuMgr.Tests/FileDownloadingTestbed/_.cs
@@ -55,7 +55,7 @@ namespace Laerdal.McuMgr.Tests.FileDownloadingTestbed
                 => _downloaderCallbacksProxy.LogMessageAdvertisement(message, category, level, resource); //raises the actual event
 
             public void StateChangedAdvertisement(string resource, EFileDownloaderState oldState, EFileDownloaderState newState)
-                => _downloaderCallbacksProxy.StateChangedAdvertisement(resource: resource, newState: newState, oldState: oldState); //raises the actual event
+                => _downloaderCallbacksProxy.StateChangedAdvertisement(resourceId: resource, newState: newState, oldState: oldState); //raises the actual event
 
             public void BusyStateChangedAdvertisement(bool busyNotIdle)
                 => _downloaderCallbacksProxy.BusyStateChangedAdvertisement(busyNotIdle); //raises the actual event
@@ -66,8 +66,8 @@ namespace Laerdal.McuMgr.Tests.FileDownloadingTestbed
             public void FatalErrorOccurredAdvertisement(string resource, string errorMessage, EGlobalErrorCode globalErrorCode) 
                 => _downloaderCallbacksProxy.FatalErrorOccurredAdvertisement(resource, errorMessage, globalErrorCode); //raises the actual event
             
-            public void FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(int progressPercentage, float currentThroughputInKbps, float totalAverageThroughputInKbps)
-                => _downloaderCallbacksProxy.FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(progressPercentage, currentThroughputInKbps, totalAverageThroughputInKbps); //raises the actual event
+            public void FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(string resourceId, int progressPercentage, float currentThroughputInKbps, float totalAverageThroughputInKbps)
+                => _downloaderCallbacksProxy.FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(resourceId, progressPercentage, currentThroughputInKbps, totalAverageThroughputInKbps); //raises the actual event
             
             public bool TrySetContext(object context) => throw new NotImplementedException();
             public bool TrySetBluetoothDevice(object bluetoothDevice) => throw new NotImplementedException();

--- a/Laerdal.McuMgr/Droid/FileDownloading/FileDownloader.cs
+++ b/Laerdal.McuMgr/Droid/FileDownloading/FileDownloader.cs
@@ -227,16 +227,17 @@ namespace Laerdal.McuMgr.FileDownloading
             public void StateChangedAdvertisement(string resource, EFileDownloaderState oldState, EFileDownloaderState newState)
             {
                 _fileDownloaderCallbacksProxy?.StateChangedAdvertisement(
-                    resource: resource,
+                    resourceId: resource,
                     oldState: oldState,
                     newState: newState);
             }
 
-            public override void FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(int progressPercentage, float currentThroughputInKbps, float totalAverageThroughputInKbps)
+            public override void FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(string resourceId, int progressPercentage, float currentThroughputInKbps, float totalAverageThroughputInKbps)
             {
-                base.FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(progressPercentage, currentThroughputInKbps, totalAverageThroughputInKbps); //just in case
+                base.FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(resourceId, progressPercentage, currentThroughputInKbps, totalAverageThroughputInKbps); //just in case
 
                 _fileDownloaderCallbacksProxy?.FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(
+                    resourceId: resourceId,
                     progressPercentage: progressPercentage,
                     currentThroughputInKbps: currentThroughputInKbps,
                     totalAverageThroughputInKbps: totalAverageThroughputInKbps

--- a/Laerdal.McuMgr/Shared/FileDownloading/Contracts/Events/FileDownloadProgressPercentageAndDataThroughputChangedEventArgs.cs
+++ b/Laerdal.McuMgr/Shared/FileDownloading/Contracts/Events/FileDownloadProgressPercentageAndDataThroughputChangedEventArgs.cs
@@ -8,23 +8,28 @@ namespace Laerdal.McuMgr.FileDownloading.Contracts.Events
 {
     public readonly struct FileDownloadProgressPercentageAndDataThroughputChangedEventArgs : IMcuMgrEventArgs //hotpath
     {
+        public readonly string ResourceId;
         public readonly int ProgressPercentage;
         public readonly float CurrentThroughputInKbps; //      kbs / sec
         public readonly float TotalAverageThroughputInKbps; // kbs / sec
 
-        public FileDownloadProgressPercentageAndDataThroughputChangedEventArgs(int progressPercentage, float currentThroughputInKbps, float totalAverageThroughputInKbps)
+        public FileDownloadProgressPercentageAndDataThroughputChangedEventArgs(string resourceId, int progressPercentage, float currentThroughputInKbps, float totalAverageThroughputInKbps)
         {
-            ProgressPercentage = progressPercentage;
+            ArgumentOutOfRangeException.ThrowIfNegative(currentThroughputInKbps, nameof(totalAverageThroughputInKbps));
+            ArgumentOutOfRangeException.ThrowIfNegative(totalAverageThroughputInKbps, nameof(totalAverageThroughputInKbps));
             
-            CurrentThroughputInKbps = (float)Math.Round( //14.1999 -> 14.2
-                mode: MidpointRounding.AwayFromZero,
-                value: currentThroughputInKbps,
-                digits: 1
-            );
+            ResourceId = resourceId ?? throw new ArgumentNullException(nameof(resourceId));
+            ProgressPercentage = progressPercentage is >= 0 and <= 100
+                ? progressPercentage
+                : throw new ArgumentOutOfRangeException(nameof(progressPercentage), "Progress percentage must be between 0 and 100.");
             
-            TotalAverageThroughputInKbps = (float)Math.Round( //14.1999 -> 14.2
+            CurrentThroughputInKbps = RoundThroughput_(currentThroughputInKbps);
+            TotalAverageThroughputInKbps = RoundThroughput_(totalAverageThroughputInKbps);
+            return;
+
+            static float RoundThroughput_(float value_) => (float) Math.Round( //14.1999 -> 14.2
                 mode: MidpointRounding.AwayFromZero,
-                value: totalAverageThroughputInKbps,
+                value: value_,
                 digits: 1
             );
         }

--- a/Laerdal.McuMgr/Shared/FileDownloading/Contracts/Native/INativeFileDownloaderCallbacksProxy.cs
+++ b/Laerdal.McuMgr/Shared/FileDownloading/Contracts/Native/INativeFileDownloaderCallbacksProxy.cs
@@ -9,10 +9,10 @@ namespace Laerdal.McuMgr.FileDownloading.Contracts.Native
 
         void CancelledAdvertisement();
         void LogMessageAdvertisement(string message, string category, ELogLevel level, string resource);
-        void StateChangedAdvertisement(string resource, EFileDownloaderState oldState, EFileDownloaderState newState);
+        void StateChangedAdvertisement(string resourceId, EFileDownloaderState oldState, EFileDownloaderState newState);
         void BusyStateChangedAdvertisement(bool busyNotIdle);
-        void DownloadCompletedAdvertisement(string resource, byte[] data);
-        void FatalErrorOccurredAdvertisement(string resource, string errorMessage, EGlobalErrorCode globalErrorCode);
-        void FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(int progressPercentage, float currentThroughputInKbps, float totalAverageThroughputInKbps);
+        void DownloadCompletedAdvertisement(string resourceId, byte[] data);
+        void FatalErrorOccurredAdvertisement(string resourceId, string errorMessage, EGlobalErrorCode globalErrorCode);
+        void FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(string resourceId, int progressPercentage, float currentThroughputInKbps, float totalAverageThroughputInKbps);
     }
 }

--- a/Laerdal.McuMgr/Shared/FileDownloading/FileDownloader.cs
+++ b/Laerdal.McuMgr/Shared/FileDownloading/FileDownloader.cs
@@ -520,9 +520,9 @@ namespace Laerdal.McuMgr.FileDownloading
                     resource: resource
                 ));
 
-            public void StateChangedAdvertisement(string resource, EFileDownloaderState oldState, EFileDownloaderState newState)
+            public void StateChangedAdvertisement(string resourceId, EFileDownloaderState oldState, EFileDownloaderState newState)
                 => FileDownloader?.OnStateChanged(new StateChangedEventArgs(
-                    resource: resource,
+                    resource: resourceId,
                     newState: newState,
                     oldState: oldState
                 ));
@@ -530,14 +530,15 @@ namespace Laerdal.McuMgr.FileDownloading
             public void BusyStateChangedAdvertisement(bool busyNotIdle)
                 => FileDownloader?.OnBusyStateChanged(new BusyStateChangedEventArgs(busyNotIdle));
 
-            public void DownloadCompletedAdvertisement(string resource, byte[] data)
-                => FileDownloader?.OnDownloadCompleted(new DownloadCompletedEventArgs(resource, data));
+            public void DownloadCompletedAdvertisement(string resourceId, byte[] data)
+                => FileDownloader?.OnDownloadCompleted(new DownloadCompletedEventArgs(resourceId, data));
 
-            public void FatalErrorOccurredAdvertisement(string resource, string errorMessage, EGlobalErrorCode globalErrorCode)
-                => FileDownloader?.OnFatalErrorOccurred(new FatalErrorOccurredEventArgs(resource, errorMessage, globalErrorCode));
+            public void FatalErrorOccurredAdvertisement(string resourceId, string errorMessage, EGlobalErrorCode globalErrorCode)
+                => FileDownloader?.OnFatalErrorOccurred(new FatalErrorOccurredEventArgs(resourceId, errorMessage, globalErrorCode));
 
-            public void FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(int progressPercentage, float currentThroughputInKbps, float totalAverageThroughputInKbps)
+            public void FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(string resourceId, int progressPercentage, float currentThroughputInKbps, float totalAverageThroughputInKbps)
                 => FileDownloader?.OnFileDownloadProgressPercentageAndDataThroughputChanged(new FileDownloadProgressPercentageAndDataThroughputChangedEventArgs(
+                    resourceId: resourceId,
                     progressPercentage: progressPercentage,
                     currentThroughputInKbps: currentThroughputInKbps,
                     totalAverageThroughputInKbps: totalAverageThroughputInKbps

--- a/Laerdal.McuMgr/iOS/FileDownloading/FileDownloader.cs
+++ b/Laerdal.McuMgr/iOS/FileDownloading/FileDownloader.cs
@@ -164,15 +164,15 @@ namespace Laerdal.McuMgr.FileDownloading
                     resource: resource
                 );
 
-            public override void StateChangedAdvertisement(string resource, EIOSFileDownloaderState oldState, EIOSFileDownloaderState newState)
+            public override void StateChangedAdvertisement(string resourceId, EIOSFileDownloaderState oldState, EIOSFileDownloaderState newState)
                 => StateChangedAdvertisement(
-                    resource: resource, //essentially the remote filepath
+                    resourceId: resourceId, //essentially the remote filepath
                     newState: TranslateEIOSFileDownloaderState(newState),
                     oldState: TranslateEIOSFileDownloaderState(oldState)
                 );
-            public void StateChangedAdvertisement(string resource, EFileDownloaderState oldState, EFileDownloaderState newState) //conformance to the interface
+            public void StateChangedAdvertisement(string resourceId, EFileDownloaderState oldState, EFileDownloaderState newState) //conformance to the interface
                 => _nativeFileDownloaderCallbacksProxy?.StateChangedAdvertisement(
-                    resource: resource, //essentially the remote filepath
+                    resourceId: resourceId, //essentially the remote filepath
                     newState: newState,
                     oldState: oldState
                 );
@@ -180,7 +180,7 @@ namespace Laerdal.McuMgr.FileDownloading
             public override void BusyStateChangedAdvertisement(bool busyNotIdle)
                 => _nativeFileDownloaderCallbacksProxy?.BusyStateChangedAdvertisement(busyNotIdle);
             
-            public override void DownloadCompletedAdvertisement(string resource, NSNumber[] data)
+            public override void DownloadCompletedAdvertisement(string resourceId, NSNumber[] data)
             {
                 var dataBytes = new byte[data.Length];
                 for (var i = 0; i < data.Length; i++)
@@ -188,29 +188,29 @@ namespace Laerdal.McuMgr.FileDownloading
                     dataBytes[i] = data[i].ByteValue;
                 }
 
-                DownloadCompletedAdvertisement(resource, dataBytes);
+                DownloadCompletedAdvertisement(resourceId, dataBytes);
             }
 
-            public void DownloadCompletedAdvertisement(string resource, byte[] data) //conformance to the interface
-                => _nativeFileDownloaderCallbacksProxy?.DownloadCompletedAdvertisement(resource, data);
+            public void DownloadCompletedAdvertisement(string resourceId, byte[] data) //conformance to the interface
+                => _nativeFileDownloaderCallbacksProxy?.DownloadCompletedAdvertisement(resourceId, data);
 
             public override void FatalErrorOccurredAdvertisement(
-                string resource,
+                string resourceId,
                 string errorMessage,
                 nint globalErrorCode
             ) => FatalErrorOccurredAdvertisement(
-                resource,
+                resourceId,
                 errorMessage,
                 (EGlobalErrorCode)(int)globalErrorCode
             );
 
-            public void FatalErrorOccurredAdvertisement(string resource, string errorMessage, EGlobalErrorCode globalErrorCode)
-                => _nativeFileDownloaderCallbacksProxy?.FatalErrorOccurredAdvertisement(resource, errorMessage, globalErrorCode);
+            public void FatalErrorOccurredAdvertisement(string resourceId, string errorMessage, EGlobalErrorCode globalErrorCode)
+                => _nativeFileDownloaderCallbacksProxy?.FatalErrorOccurredAdvertisement(resourceId, errorMessage, globalErrorCode);
 
-            public override void FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(nint progressPercentage, float currentThroughputInKbps, float totalAverageThroughputInKbps)
-                => FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(progressPercentage: (int)progressPercentage, currentThroughputInKbps: currentThroughputInKbps, totalAverageThroughputInKbps: totalAverageThroughputInKbps);
-            public void FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(int progressPercentage, float currentThroughputInKbps, float totalAverageThroughputInKbps) //conformance to the interface
-                => _nativeFileDownloaderCallbacksProxy?.FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(progressPercentage: progressPercentage, currentThroughputInKbps: currentThroughputInKbps, totalAverageThroughputInKbps: totalAverageThroughputInKbps);
+            public override void FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(string resourceId, nint progressPercentage, float currentThroughputInKbps, float totalAverageThroughputInKbps)
+                => FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(resourceId: resourceId, progressPercentage: (int)progressPercentage, currentThroughputInKbps: currentThroughputInKbps, totalAverageThroughputInKbps: totalAverageThroughputInKbps);
+            public void FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(string resourceId, int progressPercentage, float currentThroughputInKbps, float totalAverageThroughputInKbps) //conformance to the interface
+                => _nativeFileDownloaderCallbacksProxy?.FileDownloadProgressPercentageAndDataThroughputChangedAdvertisement(resourceId: resourceId, progressPercentage: progressPercentage, currentThroughputInKbps: currentThroughputInKbps, totalAverageThroughputInKbps: totalAverageThroughputInKbps);
             
             #endregion
 


### PR DESCRIPTION
The file-downloader-progress%-changed event now includes the resource-id as well