### PR TITLE
[MAN-619b] Include file-paths in file events

### DIFF
--- a/Laerdal.McuMgr.Bindings.Android.Native/mcumgr-laerdal-wrapper/src/main/java/no/laerdal/mcumgr_laerdal_wrapper/AndroidFileDownloader.java
+++ b/Laerdal.McuMgr.Bindings.Android.Native/mcumgr-laerdal-wrapper/src/main/java/no/laerdal/mcumgr_laerdal_wrapper/AndroidFileDownloader.java
@@ -225,9 +225,10 @@ public class AndroidFileDownloader
 
     private void resetDownloadState()
     {
+        _downloadStartTimestampInMs = 0;
+
         _lastBytesSent = 0;
         _lastBytesSentTimestampInMs = 0;
-        _downloadStartTimestampInMs = 0;
 
         setState(EAndroidFileDownloaderState.IDLE);
         busyStateChangedAdvertisement(true);

--- a/Laerdal.McuMgr.Bindings.Android.Native/mcumgr-laerdal-wrapper/src/main/java/no/laerdal/mcumgr_laerdal_wrapper/AndroidFileUploader.java
+++ b/Laerdal.McuMgr.Bindings.Android.Native/mcumgr-laerdal-wrapper/src/main/java/no/laerdal/mcumgr_laerdal_wrapper/AndroidFileUploader.java
@@ -208,8 +208,9 @@ public class AndroidFileUploader
 
     private void resetUploadState()
     {
-        _lastBytesSent = 0;
         _uploadStartTimestampInMs = 0;
+
+        _lastBytesSent = 0;
         _lastBytesSentTimestampInMs = 0;
 
         setState(EAndroidFileUploaderState.IDLE);

--- a/Laerdal.McuMgr.Bindings.MacCatalystAndIos.Native/McuMgrBindingsiOS/McuMgrBindingsiOS/IOSFileDownloader.swift
+++ b/Laerdal.McuMgr.Bindings.MacCatalystAndIos.Native/McuMgrBindingsiOS/McuMgrBindingsiOS/IOSFileDownloader.swift
@@ -145,6 +145,8 @@ public class IOSFileDownloader: NSObject {
     }
 
     private func resetState() {
+        _downloadStartTimestamp = nil
+
         _lastBytesSent = -1
         _lastBytesSentTimestamp = nil
 


### PR DESCRIPTION
Follow-up PR to fix a bug in the iOS file-download-progress% event in regard to the total average download speed