### PR TITLE
[MAN-632] Align iOS with the Android mechanics

### DIFF
--- a/Laerdal.McuMgr.Bindings.Android.Native/mcumgr-laerdal-wrapper/src/main/java/no/laerdal/mcumgr_laerdal_wrapper/AndroidFileDownloader.java
+++ b/Laerdal.McuMgr.Bindings.Android.Native/mcumgr-laerdal-wrapper/src/main/java/no/laerdal/mcumgr_laerdal_wrapper/AndroidFileDownloader.java
@@ -232,7 +232,7 @@ public class AndroidFileDownloader
     {
         try
         {
-            _backgroundExecutor.shutdownNow();
+            _backgroundExecutor.shutdown();
             return true;
         }
         catch (final Exception ex)

--- a/Laerdal.McuMgr.Bindings.Android.Native/mcumgr-laerdal-wrapper/src/main/java/no/laerdal/mcumgr_laerdal_wrapper/AndroidFileUploader.java
+++ b/Laerdal.McuMgr.Bindings.Android.Native/mcumgr-laerdal-wrapper/src/main/java/no/laerdal/mcumgr_laerdal_wrapper/AndroidFileUploader.java
@@ -297,7 +297,7 @@ public class AndroidFileUploader
     {
         try
         {
-            _backgroundExecutor.shutdownNow();
+            _backgroundExecutor.shutdown();
             return true;
         }
         catch (final Exception ex)

--- a/Laerdal.McuMgr.Bindings.Android.Native/mcumgr-laerdal-wrapper/src/main/java/no/laerdal/mcumgr_laerdal_wrapper/AndroidFirmwareInstaller.java
+++ b/Laerdal.McuMgr.Bindings.Android.Native/mcumgr-laerdal-wrapper/src/main/java/no/laerdal/mcumgr_laerdal_wrapper/AndroidFirmwareInstaller.java
@@ -251,7 +251,7 @@ public class AndroidFirmwareInstaller
         try
         {
             _transport.release();
-            _backgroundExecutor.shutdownNow();
+            //_backgroundExecutor.shutdown(); //dont   this doesnt belong here
             emitLogEntry("Connection closed!", "firmware-installer", EAndroidLoggingLevel.Info);
         }
         catch (Exception ex)


### PR DESCRIPTION
fix (AndroidFirmwareInstaller.java): remove the call to _backgroundExecutor.shutdown() from within disconnect() considering it never belonged there in the first place and it was causing crashes upon disposal in the c# world