### PR TITLE
fix (SingleFileUploadAsync_ShouldHaveStreamAutodisposed_GivenBooleanA…

### DIFF
--- a/Laerdal.McuMgr.Tests/FileUploadingTestbed/SingleFileUploadAsync_ShouldHaveStreamAutodisposed_GivenBooleanAutodisposedParameter.cs
+++ b/Laerdal.McuMgr.Tests/FileUploadingTestbed/SingleFileUploadAsync_ShouldHaveStreamAutodisposed_GivenBooleanAutodisposedParameter.cs
@@ -56,7 +56,7 @@ namespace Laerdal.McuMgr.Tests.FileUploadingTestbed
             ));
 
             // Assert
-            await work.Should().CompleteWithinAsync(2.Seconds());
+            await work.Should().CompleteWithinAsync(10.Seconds());
 
             mockedNativeFileUploaderProxy.CancelCalled.Should().BeFalse();
             mockedNativeFileUploaderProxy.DisconnectCalled.Should().BeFalse(); //00


### PR DESCRIPTION
…utodisposedParameter.cs): increase timeout to 10secs

this test would fail due to a timeout in testcase 60 sometimes