### PR TITLE
[MAN-803] File Uploader / Downloader: Fix iOS/MacCatalyst native-error-mapping to promptly detect file-path-not-found errors

### DIFF
--- a/Laerdal.McuMgr.Bindings.MacCatalystAndIos.Native/McuMgrBindingsiOS/McuMgrBindingsiOS/IOSFileDownloader.swift
+++ b/Laerdal.McuMgr.Bindings.MacCatalystAndIos.Native/McuMgrBindingsiOS/McuMgrBindingsiOS/IOSFileDownloader.swift
@@ -467,13 +467,13 @@ extension IOSFileDownloader: FileDownloadDelegate {
     }
 
     public func downloadDidCancel() {
-        setState(.cancelled) //                                                                                    order
+        setState(.cancelled) //                                                                            order
         Task.fireAndForgetInTheBg { [weak self] in //fire and forget to boost performance                  order
             guard let self else { return }
 
             self.cancelledAdvertisement(self._cancellationReason)
         }
-        setBusyState(false) //                                                                                     order
+        setBusyState(false) //                                                                             order
     }
 
     public func download(of name: String, didFinish data: Data) {

--- a/Laerdal.McuMgr.Bindings.MacCatalystAndIos.Native/McuMgrBindingsiOS/McuMgrBindingsiOS/McuMgrExceptionHelpers.swift
+++ b/Laerdal.McuMgr.Bindings.MacCatalystAndIos.Native/McuMgrBindingsiOS/McuMgrBindingsiOS/McuMgrExceptionHelpers.swift
@@ -3,26 +3,53 @@ import iOSMcuManagerLibrary
 
 internal class McuMgrExceptionHelpers {
     internal static func deduceGlobalErrorCodeFromException(_ error: Error? = nil) -> Int { //00
-        guard let mcuMgrError = error as? McuMgrError else {
-            return -99
-        }
+        // if let error {
+        //     logInBg("[IOSFD.DGECFE.010] Error: '\(error.localizedDescription)' - type: \(type(of: error))", McuMgrLogLevel.error)
+        // } else {
+        //     logInBg("[IOSFD.DGECFE.010] Error: '(N/A!?)' - type: \(type(of: error))", McuMgrLogLevel.error)
+        // }
 
         var errorCode = -99
         var groupErrorCode = -99
         var groupSubsystemId = 0
 
-        switch mcuMgrError {
-        case .returnCode(let rc): //if smp v2 is not supported by the target device (rare these days)
-            errorCode = Int(rc.rawValue)
-        case .groupCode(let groupCode): //if smp v2 is supported by the target device
-            groupErrorCode = Int(groupCode.rc.rawValue)
-            groupSubsystemId = Int(groupCode.group)
+        if let fileTransferError = error as? FileTransferError { //20  logInBg("[IOSFD.DGECFE.012] Detected FileTransferError", McuMgrLogLevel.error)
+            groupSubsystemId = 200 // custom one for this error
+
+            groupErrorCode = 0 // generic error
+            switch fileTransferError { //@formatter:off    unfortunately nordic forgot to underpin this error with numeric values for easy analysis so we have to map it manually
+            case .invalidData:                groupErrorCode = 1
+            case .invalidPayload:             groupErrorCode = 2
+            case .missingUploadConfiguration: groupErrorCode = 3
+            } //@formatter:on
+
+        } else if let fileSystemManagerError = error as? FileSystemManagerError { //20 logInBg("[IOSFD.DGECFE.012] Detected FileSystemManagerError", McuMgrLogLevel.error)
+            groupErrorCode = Int(fileSystemManagerError.rawValue)
+            groupSubsystemId = 8 // SubSystemFilesystem
+
+        } else {
+            guard let mcuMgrError = error as? McuMgrError else { // logInBg("[IOSFD.DGECFE.015]", McuMgrLogLevel.error)
+                return -99
+            }
+
+            switch mcuMgrError {
+            case .returnCode(let rc): //if smp v2 is not supported by the target device (rare these days)
+                errorCode = Int(rc.rawValue)
+            case .groupCode(let groupCode): //if smp v2 is supported by the target device
+                groupErrorCode = Int(groupCode.rc.rawValue)
+                groupSubsystemId = Int(groupCode.group)
+            }
         }
 
-        return groupSubsystemId == 0
+        let eventualErrorCode = groupSubsystemId == 0
                 ? errorCode
-                : ((groupSubsystemId + 1) * 1_000 + groupErrorCode);
+                : ((groupSubsystemId + 1) * 1_000 + groupErrorCode) // logInBg("[IOSFD.DGECFE.100] eventualErrorCode=\(eventualErrorCode)", McuMgrLogLevel.error)
+
+        return eventualErrorCode
 
         //00   https://github.com/NordicSemiconductor/IOS-nRF-Connect-Device-Manager/issues/198
+        //
+        //20   in ios (unlike android) we do get non-mcumgr exceptions and we have to process
+        //     them properly to deduce the appropriate eventual compound-error-code
     }
 }

--- a/Laerdal.McuMgr/Shared/Common/Enums/EGlobalErrorCode.cs
+++ b/Laerdal.McuMgr/Shared/Common/Enums/EGlobalErrorCode.cs
@@ -3,7 +3,7 @@ namespace Laerdal.McuMgr.Common.Enums
     public enum EGlobalErrorCode //@formatter:off https://github.com/NordicSemiconductor/Android-nRF-Connect-Device-Manager/issues/201#issuecomment-2440126159
     {
         Unset   = -99, //this is our own to mark that we haven't received any error code from the device
-        Generic =  -1, //in case the underlying native code receives an exception other than io.runtime.mcumgr.exception.McuMgrErrorException
+        Generic =  -1, //in case the underlying native code receives an exception other than io.runtime.mcumgr.exception.*Error
         
         // must mirror  mcumgr-core/src/main/java/io/runtime/mcumgr/exception/McuMgrErrorException.java
         McuMgrErrorBeforeSmpV2_Ok                       =  000,
@@ -86,7 +86,7 @@ namespace Laerdal.McuMgr.Common.Enums
         SubSystemFilesystem_Ok                          = 9000,
         SubSystemFilesystem_Unknown                     = 9001,
         SubSystemFilesystem_InvalidName                 = 9002,
-        SubSystemFilesystem_NotFound                    = 9003,
+        SubSystemFilesystem_NotFound                    = 9003, //when trying to download a file that doesnt exist on the remote device
         SubSystemFilesystem_IsDirectory                 = 9004,
         SubSystemFilesystem_OpenFailed                  = 9005,
         SubSystemFilesystem_SeekFailed                  = 9006,
@@ -105,5 +105,10 @@ namespace Laerdal.McuMgr.Common.Enums
         SubSystemShell_Unknown                          = 10001,
         SubSystemShell_CommandTooLong                   = 10002,
         SubSystemShell_EmptyCommand                     = 10003,
+        
+        SubSystemFileTransporter_GenericError                = 200 * 1000 + 0, //this is for the legacy FileTransferError in iOS that doesnt derive from zephyr
+        SubSystemFileTransporter_InvalidData                 = 200 * 1000 + 1,
+        SubSystemFileTransporter_InvalidPayload              = 200 * 1000 + 2,
+        SubSystemFileTransporter_MissingUploadConfiguration  = 200 * 1000 + 3,
     }
 }

--- a/Laerdal.McuMgr/iOS/FileDownloading/FileDownloader.cs
+++ b/Laerdal.McuMgr/iOS/FileDownloading/FileDownloader.cs
@@ -225,7 +225,6 @@ namespace Laerdal.McuMgr.FileDownloading
             
             #endregion
 
-                        
             static private EFileDownloaderVerdict TranslateFileDownloaderVerdict(EIOSFileDownloadingInitializationVerdict verdict)
             {
                 if (verdict == EIOSFileDownloadingInitializationVerdict.Success) //0


### PR DESCRIPTION
fix (McuMgrExceptionHelpers.swift): enhance the method to account for FileTransferError and most importantly FileSystemManagerError so as to properly handle even non-mcumgr-exceptions that the ios file-uploader and file-downloader stacks emit

This causes the associated file-uploading / file-downloading operations to bail out quickly in iOS as intended (old was: retrying in vein until max-tries-count was reached which was causing a lot of noise)